### PR TITLE
build: remove release trigger

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,6 @@ on:
   release:
     types: 
     - published
-    - released
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
Remove release trigger in github actions in order to avoid double triggering